### PR TITLE
Add level 2 compiler optimizations

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 TARGET := LAST
 
 INC := -I/usr/include/lua5.* `pkg-config --cflags gtk+-3.0 x11 jansson`
-CFLAGS := -std=gnu99 -O0 -pthread -Wall -Wno-unused-parameter
+CFLAGS := -std=gnu99 -O2 -pthread -Wall -Wno-unused-parameter
 LDFLAGS := -llua `pkg-config --libs gtk+-3.0 x11 jansson`
 
 SRC_DIR := ./src


### PR DESCRIPTION
Thanks to pull request #18, LAST now seems to work with level 2 compiler optimizations. I tested a few levels of Jet Set Radio and didn't seem to get any segfaults or other issues.

I would like this to be tested across different distros and hardware before merging though.

My setup for comparison:
```
OS: Arch Linux
GPU: NVIDIA GeForce RTX 3050 Mobile
CPU: Intel Core i5-11400H
```