### PR TITLE
Add GitHub CI for build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,33 @@
+on: [push, pull_request]
+
+jobs:
+  tests:
+    runs-on: ubuntu-latest
+    name: Build
+    steps:
+      - name: "Checkout" 
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: "Install dependencies"
+        run: |
+          sudo apt -y update
+          sudo apt -y install libgtk-3-dev libx11-dev libjansson-dev liblua5.4-dev
+
+      - name: "Run make clean and make"
+        run: make clean && make -j
+
+      - name: Set Build number
+        shell: bash
+        run: echo "build_number=$(git rev-list HEAD --count)" >> $GITHUB_ENV
+
+      - name: Compute git short sha
+        shell: bash
+        run: echo "git_short_sha=$(git rev-parse --short HEAD)" >> $GITHUB_ENV
+
+      - name: "Upload artifacts"
+        uses: actions/upload-artifact@v4
+        with:
+          name: LAST-${{ env.build_number }}-${{ env.git_short_sha }}
+          path: LAST

--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,8 @@
 TARGET := LAST
 
-INC := -I/usr/include/lua5.* `pkg-config --cflags gtk+-3.0 x11 jansson`
+INC := -I/usr/include/lua5.* `pkg-config --cflags gtk+-3.0 x11 jansson lua`
 CFLAGS := -std=gnu99 -O0 -pthread -Wall -Wno-unused-parameter
-LDFLAGS := -llua `pkg-config --libs gtk+-3.0 x11 jansson`
+LDFLAGS := `pkg-config --libs gtk+-3.0 x11 jansson lua`
 
 SRC_DIR := ./src
 OBJ_DIR := ./obj


### PR DESCRIPTION
Adds a Github CI for building LAST, mainly for testing on PRs to check if it builds or not, it gets triggered on every commit.

Whenever CI builds correctly it build upload the LAST binary as an artifact, this is so its easier to test the changes, unfortunately the binary is not marked as executable (https://github.com/actions/upload-artifact/issues/38) :(

Preview of the CI artifacts are here: https://github.com/EXtremeExploit/LAST/actions/runs/8274731109

The artifact zip name is "LAST-(number of commits)-(short git sha)"m it only contains the LAST binary, so in the case that extra files are needed the Makefile would need to build LAST in a separate directory and make the upload-artifact task upload the folder instead of the only binary

Also changed how lua gets added on the Makefile. pkg-config knows better how to add lua in both flags than having it be done manually, without this it wasnt compiling on the CI because it wasnt the library

TODO for later: Check if now with lua added in both pkg-config if `-I/usr/include/lua5.*` is still needed