### PR TITLE
Make LAST use the XDG specification

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@ obj/
 src/last-gtk.h
 
 .vscode/
+.cache/
+compile_commands.json

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ sudo make build install
 ## Getting Started
 
 1. Launch LAST by executing the compiled binary. `./LAST`
-2. When first launched, LAST will create the `.last/` directory in your home directory. Auto splitters, splits and themes go in their respective folders inside.
+2. When first launched, LAST will create the `LAST` directory in your config directory. Auto splitters, splits and themes go in their respective folders inside.
 3. The initial window is undecorated, but you can toggle window decorations by pressing the right Control key.
 4. Control the timer using the following key presses:
 
@@ -107,7 +107,7 @@ Times are strings in HH:MM:SS.mmmmmm format
 LAST supports customizable themes, allowing you to personalize the timer's appearance. To create a theme:
 
 1. Create a CSS stylesheet with your desired styles.
-2. Place the stylesheet in the `~/.last/themes/<name>/<name>.css` directory.
+2. Place the stylesheet in the `~/.config/LAST/themes/<name>/<name>.css` directory. (If you have `XDG_CONFIG_HOME` env var pointing somewher else than .config it will be wherever it points to)
 3. Set the global theme by modifying the `theme` value in `gsettings`.
 4. Theme variants should follow the pattern `<name>-<variant>.css`.
 5. Individual splits can apply their own themes by specifying a `theme` key in the main split object.

--- a/src/auto-splitter.h
+++ b/src/auto-splitter.h
@@ -1,6 +1,7 @@
 #ifndef __AUTO_SPLITTER_H__
 #define __AUTO_SPLITTER_H__
 
+#include <linux/limits.h>
 #include <stdatomic.h>
 
 extern atomic_bool auto_splitter_enabled;
@@ -8,7 +9,7 @@ extern atomic_bool call_start;
 extern atomic_bool call_split;
 extern atomic_bool toggle_loading;
 extern atomic_bool call_reset;
-extern char auto_splitter_file[256];
+extern char auto_splitter_file[PATH_MAX];
 
 void check_directories();
 void *last_auto_splitter();

--- a/src/settings.c
+++ b/src/settings.c
@@ -1,3 +1,4 @@
+#include <linux/limits.h>
 #include <stdio.h>
 #include <pwd.h>
 #include <string.h>
@@ -9,23 +10,24 @@
 
 #include "settings.h"
 
-char *get_home_folder_path()
-{
-    uid_t uid = getuid();
-    struct passwd *pw = getpwuid(uid);
-    if (pw == NULL)
-    {
-        printf("Failed to get user information.\n");
-        return NULL;
+void get_LAST_folder_path(char* out_path) {
+    struct passwd * pw = getpwuid(getuid());
+    char* XDG_CONFIG_HOME = getenv("XDG_CONFIG_HOME");
+    char* base_dir = strcat(pw->pw_dir, "/.config/LAST");
+    if (XDG_CONFIG_HOME != NULL) {
+        char config_dir[PATH_MAX] = {0};
+        strcpy(config_dir, XDG_CONFIG_HOME);
+        strcat(config_dir, "/LAST");
+        strcpy(base_dir, config_dir);
     }
-
-    return pw->pw_dir;
+    strcpy(out_path, base_dir);
 }
 
 void last_update_setting(const char *setting, json_t *value)
 {
-    char *settings_path = get_home_folder_path();
-    strcat(settings_path, "/.last/settings.json");
+    char settings_path[PATH_MAX];
+    get_LAST_folder_path(settings_path);
+    strcat(settings_path, "/settings.json");
 
     // Load existing settings
     json_t *root = NULL;
@@ -73,8 +75,10 @@ void last_update_setting(const char *setting, json_t *value)
 
 json_t *load_settings()
 {
-    char *settings_path = get_home_folder_path();
-    strcat(settings_path, "/.last/settings.json");
+    char settings_path[PATH_MAX];
+    get_LAST_folder_path(settings_path);
+    strcat(settings_path, "/settings.json");
+
     FILE *file = fopen(settings_path, "r");
     if (file)
     {

--- a/src/settings.h
+++ b/src/settings.h
@@ -3,6 +3,7 @@
 
 #include <jansson.h>
 
+void get_LAST_folder_path(char* out_path);
 void last_update_setting(const char *setting, json_t *value);
 json_t *get_setting_value(const char *section, const char *setting);
 


### PR DESCRIPTION
Currently LAST places all its files in `~/.last`, this is kinda bad as it is bad practice to place files dot files in the home folder just because yolo, there are some standards as to where stuff goes in linux, and XDG specification is extremely widely used (its what defines what goes in .local/share, .config, .cache, etc).
So this PR makes that, all the files LAST uses should be now in `(XDG_CONFIG_HOME)/LAST`, "XDG_CONFIG_HOME" refers to the environment var with the same name, if this one is not present (most of the time), it will fallback to `~/.config/LAST`

Of course, the only downside i can think of is that people that already run LAST will have to move their stuff to `~/.config/LAST`, else it will just dont detect any configuration. The more early XDG spec is implemented the more minimized this downside will be

TODO:
- [x] **Fix potential problem when `XDG_CONFIG_HOME` or `~/.config` folder is not created**

Extras: Fixes a warning about snprintf arguments not being the correct size and fixes paths being wrong when they are more than 255 characters long