### PR TITLE
Added dependabot to auto-update LAST-Extras submodule

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,7 @@
+version: 2
+
+updates:
+  - package-ecosystem: gitsubmodule
+    schedule:
+      interval: "daily"
+    directory: /


### PR DESCRIPTION
It will make a PR if the submodule has been updated. Set to run daily but it will only automatically run on weekdays (Monday to Friday).

https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#scheduleinterval