### PR TITLE
Add getPid function to lua context

### DIFF
--- a/src/auto-splitter.c
+++ b/src/auto-splitter.c
@@ -163,6 +163,8 @@ void run_auto_splitter()
     lua_setglobal(L, "process");
     lua_pushcfunction(L, read_address);
     lua_setglobal(L, "readAddress");
+    lua_pushcfunction(L, getPid);
+    lua_setglobal(L, "getPID");
 
     char current_file[PATH_MAX];
     strcpy(current_file, auto_splitter_file);

--- a/src/process.c
+++ b/src/process.c
@@ -110,6 +110,11 @@ int find_process_id(lua_State* L)
     return 0;
 }
 
+int getPid(lua_State* L) {
+    lua_pushinteger(L, process.pid);
+    return 1;
+}
+
 int process_exists()
 {
     int result = kill(process.pid, 0);

--- a/src/process.h
+++ b/src/process.h
@@ -17,5 +17,6 @@ typedef struct last_process last_process;
 uintptr_t find_base_address(const char* module);
 int process_exists();
 int find_process_id(lua_State* L);
+int getPid(lua_State* L);
 
 #endif /* __PROCESS_H__ */


### PR DESCRIPTION
Allows the lua auto splitter script to know the PID we are working with, simplifies A LOT egde cases where the lua script needs some information about the process like enviroment variables or cmdlines or wants to do some stuff manually, just nice to have option at least