### PR TITLE
Simplify and reduce number of threads

### DIFF
--- a/src/auto-splitter.c
+++ b/src/auto-splitter.c
@@ -261,15 +261,3 @@ void run_auto_splitter()
 
     lua_close(L);
 }
-
-void *last_auto_splitter()
-{
-    while (true)
-    {
-        if (atomic_load(&auto_splitter_enabled) && auto_splitter_file[0] != '\0')
-        {
-            run_auto_splitter();
-        }
-        usleep(1000000); // Wait for 1 second before checking again
-    }
-}

--- a/src/auto-splitter.h
+++ b/src/auto-splitter.h
@@ -11,6 +11,6 @@ extern atomic_bool call_reset;
 extern char auto_splitter_file[256];
 
 void check_directories();
-void *last_auto_splitter();
+void run_auto_splitter();
 
 #endif /* __AUTO_SPLITTER_H__ */


### PR DESCRIPTION
Moved the last_auto_splitter function to last-gtk.c, removed the ThreadArgs struct and the 2nd pthread that was created because the timer can just continue to run in the main thread instead.