### PR TITLE
Replace Lua with LuaJIT and restrict loaded libraries for auto splitters

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,7 +13,7 @@ jobs:
       - name: "Install dependencies"
         run: |
           sudo apt -y update
-          sudo apt -y install libgtk-3-dev libx11-dev libjansson-dev liblua5.4-dev
+          sudo apt -y install libgtk-3-dev libx11-dev libjansson-dev libluajit-5.1-dev
 
       - name: "Run make clean and make"
         run: make clean && make -j

--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,8 @@
 TARGET := LAST
 
-INC := `pkg-config --cflags gtk+-3.0 x11 jansson lua`
+INC := `pkg-config --cflags gtk+-3.0 x11 jansson luajit`
 CFLAGS := -std=gnu99 -O2 -pthread -Wall -Wno-unused-parameter
-LDFLAGS := `pkg-config --libs gtk+-3.0 x11 jansson lua`
+LDFLAGS := `pkg-config --libs gtk+-3.0 x11 jansson luajit`
 
 SRC_DIR := ./src
 OBJ_DIR := ./obj

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ LAST requires the following dependencies on your system to compile:
 - `libgtk+-3.0`
 - `x11`
 - `libjansson`
-- `lua`
+- `luajit`
 
 And to install:
 

--- a/src/auto-splitter.c
+++ b/src/auto-splitter.c
@@ -107,6 +107,7 @@ static const luaL_Reg lj_lib_load[] = {
   { "",            luaopen_base },
   { LUA_STRLIBNAME,    luaopen_string },
   { LUA_MATHLIBNAME,    luaopen_math },
+  { LUA_BITLIBNAME,    luaopen_bit },
   { LUA_JITLIBNAME,    luaopen_jit },
   { NULL,        NULL }
 };

--- a/src/auto-splitter.c
+++ b/src/auto-splitter.c
@@ -26,7 +26,7 @@ atomic_bool toggle_loading = false;
 atomic_bool call_reset = false;
 bool prev_is_loading;
 
-static const char* functions[] = {
+static const char* disabled_functions[] = {
     "collectgarbage",
     "dofile",
     "getmetatable",
@@ -303,7 +303,7 @@ void run_auto_splitter()
 {
     lua_State* L = luaL_newstate();
     luaL_openlibs(L);
-    disable_functions(L, functions);
+    disable_functions(L, disabled_functions);
     lua_pushcfunction(L, find_process_id);
     lua_setglobal(L, "process");
     lua_pushcfunction(L, read_address);

--- a/src/auto-splitter.c
+++ b/src/auto-splitter.c
@@ -8,9 +8,9 @@
 #include <sys/stat.h>
 #include <string.h>
 
-#include <lua.h>
-#include <lauxlib.h>
+#include <luajit.h>
 #include <lualib.h>
+#include <lauxlib.h>
 
 #include "memory.h"
 #include "auto-splitter.h"

--- a/src/auto-splitter.c
+++ b/src/auto-splitter.c
@@ -85,6 +85,24 @@ void check_directories()
     }
 }
 
+static const luaL_Reg lj_lib_load[] = {
+  { "",            luaopen_base },
+  { LUA_STRLIBNAME,    luaopen_string },
+  { LUA_MATHLIBNAME,    luaopen_math },
+  { LUA_JITLIBNAME,    luaopen_jit },
+  { NULL,        NULL }
+};
+
+LUALIB_API void luaL_openlibs(lua_State *L)
+{
+  const luaL_Reg *lib;
+  for (lib = lj_lib_load; lib->func; lib++) {
+    lua_pushcfunction(L, lib->func);
+    lua_pushstring(L, lib->name);
+    lua_call(L, 1, 0);
+  }
+}
+
 void startup(lua_State* L)
 {
     lua_getglobal(L, "startup");

--- a/src/auto-splitter.c
+++ b/src/auto-splitter.c
@@ -26,6 +26,24 @@ atomic_bool toggle_loading = false;
 atomic_bool call_reset = false;
 bool prev_is_loading;
 
+static const char* functions[] = {
+    "collectgarbage",
+    "dofile",
+    "getmetatable",
+    "setmetatable",
+    "getfenv",
+    "setfenv",
+    "load",
+    "loadfile",
+    "loadstring",
+    "rawequal",
+    "rawget",
+    "rawset",
+    "module",
+    "require",
+    "newproxy",
+};
+
 extern last_process process;
 
 // I have no idea how this works
@@ -103,6 +121,15 @@ LUALIB_API void luaL_openlibs(lua_State *L)
   }
 }
 
+void disable_functions(lua_State* L, const char** functions)
+{
+    for (int i = 0; functions[i] != NULL; i++)
+    {
+        lua_pushnil(L);
+        lua_setglobal(L, functions[i]);
+    }
+}
+
 void startup(lua_State* L)
 {
     lua_getglobal(L, "startup");
@@ -177,6 +204,7 @@ void run_auto_splitter()
 {
     lua_State* L = luaL_newstate();
     luaL_openlibs(L);
+    disable_functions(L, functions);
     lua_pushcfunction(L, find_process_id);
     lua_setglobal(L, "process");
     lua_pushcfunction(L, read_address);

--- a/src/memory.c
+++ b/src/memory.c
@@ -5,7 +5,7 @@
 #include <string.h>
 #include <sys/uio.h>
 
-#include <lua.h>
+#include <luajit.h>
 
 #include "memory.h"
 #include "process.h"

--- a/src/memory.h
+++ b/src/memory.h
@@ -1,7 +1,7 @@
 #ifndef __MEMORY_H__
 #define __MEMORY_H__
 
-#include <lua.h>
+#include <luajit.h>
 #include <sys/uio.h>
 #include <stdlib.h>
 

--- a/src/process.c
+++ b/src/process.c
@@ -5,7 +5,7 @@
 #include <unistd.h>
 #include <signal.h>
 
-#include <lua.h>
+#include <luajit.h>
 
 #include "process.h"
 #include "auto-splitter.h"

--- a/src/process.h
+++ b/src/process.h
@@ -3,7 +3,7 @@
 
 #include <stdint.h>
 
-#include <lua.h>
+#include <luajit.h>
 
 struct last_process
 {


### PR DESCRIPTION
Restrict the loaded libraries to only base, string, math and jit. This is based on information from:
http://lua-users.org/wiki/SandBoxes

TODO:
- [x] Further restrict the use of unsafe functions in the base library (e.g. setmetatable)
- [ ] Test current auto splitters with the changes