### PR TITLE
Auto Splitters: Add optional cache for memory mappings

### DIFF
--- a/docs/auto-splitters.md
+++ b/docs/auto-splitters.md
@@ -285,3 +285,45 @@ end
     * A Pointer Path is a list of Offsets + a Base Address. The auto splitter reads the value at the base address and interprets the value as yet another address. It adds the first offset to this address and reads the value of the calculated address. It does this over and over until there are no more offsets. At that point, it has found the value it was searching for. This resembles the way objects are stored in memory. Every object has a clearly defined layout where each variable has a consistent offset within the object, so you basically follow these variables from object to object.
 
         * Cheat Engine is a tool that allows you to easily find Addresses and Pointer Paths for those Addresses, so you don't need to debug the game to figure out the structure of the memory.
+
+## getPID
+* Returns the current PID
+
+# Experimental stuff
+## `mapsCacheCycles`
+* When a readAddress that uses a memory map the biggest bottleneck is reading every line of `/proc/pid/maps` and checking if that line is the corresponding module. This option allows you to set for how many cycles the cache of that file should be used. The cache is global so it gets reset every x number of cycles.
+    * `0` (default): Disabled completely
+    * `1`: Enabled for the current cycle
+    * `2`: Enabled for the current cycle and the next one
+    * `3`: Enabled for the current cycle and the 2 next ones
+    * You get the idea
+  
+### Performance
+* Every uncached map finding takes around 1ms (depends a lot on your ram and cpu)
+* Every cached map finding takes around 100us
+
+* Mainly useful for lots of readAddresses and the game has uncapped game state update rate, where literally every millisecond matters
+
+### Example
+```lua
+function startup()
+    refreshRate = 60;
+    mapsCacheCycles = 1;
+end
+
+-- Assume all this readAddresses are different, 
+-- Instead of taking near 10ms it will instead take 1-2ms, because only this cycle is cached and the first readAddress is a cache miss, if the mapsCacheCycles were higher than 1 then a cycle could take less than half a millisecond
+function state()
+    current.isLoading = readAddress("bool", "UnityPlayer.dll", 0x019B4878, 0xD0, 0x8, 0x60, 0xA0, 0x18, 0xA0);
+    current.isLoading = readAddress("bool", "UnityPlayer.dll", 0x019B4878, 0xD0, 0x8, 0x60, 0xA0, 0x18, 0xA0);
+    current.isLoading = readAddress("bool", "UnityPlayer.dll", 0x019B4878, 0xD0, 0x8, 0x60, 0xA0, 0x18, 0xA0);
+    current.isLoading = readAddress("bool", "UnityPlayer.dll", 0x019B4878, 0xD0, 0x8, 0x60, 0xA0, 0x18, 0xA0);
+    current.isLoading = readAddress("bool", "UnityPlayer.dll", 0x019B4878, 0xD0, 0x8, 0x60, 0xA0, 0x18, 0xA0);
+    current.isLoading = readAddress("bool", "UnityPlayer.dll", 0x019B4878, 0xD0, 0x8, 0x60, 0xA0, 0x18, 0xA0);
+    current.isLoading = readAddress("bool", "UnityPlayer.dll", 0x019B4878, 0xD0, 0x8, 0x60, 0xA0, 0x18, 0xA0);
+    current.isLoading = readAddress("bool", "UnityPlayer.dll", 0x019B4878, 0xD0, 0x8, 0x60, 0xA0, 0x18, 0xA0);
+    current.isLoading = readAddress("bool", "UnityPlayer.dll", 0x019B4878, 0xD0, 0x8, 0x60, 0xA0, 0x18, 0xA0);
+    current.isLoading = readAddress("bool", "UnityPlayer.dll", 0x019B4878, 0xD0, 0x8, 0x60, 0xA0, 0x18, 0xA0);
+end
+
+```

--- a/src/auto-splitter.h
+++ b/src/auto-splitter.h
@@ -10,6 +10,7 @@ extern atomic_bool call_split;
 extern atomic_bool toggle_loading;
 extern atomic_bool call_reset;
 extern char auto_splitter_file[PATH_MAX];
+extern int maps_cache_cycles_value;
 
 void check_directories();
 void run_auto_splitter();

--- a/src/process.h
+++ b/src/process.h
@@ -1,6 +1,8 @@
 #ifndef __PROCESS_H__
 #define __PROCESS_H__
 
+#include <linux/limits.h>
+#include <stdbool.h>
 #include <stdint.h>
 
 #include <luajit.h>
@@ -14,9 +16,16 @@ struct last_process
 };
 typedef struct last_process last_process;
 
+typedef struct ProcessMap {
+    uint64_t start;
+    char name[PATH_MAX];
+} ProcessMap;
+extern uint32_t p_maps_cache_size;
+
 uintptr_t find_base_address(const char* module);
 int process_exists();
 int find_process_id(lua_State* L);
 int getPid(lua_State* L);
+bool parseMapsLine(char* line, ProcessMap *map);
 
 #endif /* __PROCESS_H__ */


### PR DESCRIPTION
Mainly an experimental feature (i think values 0 and 1 shouldnt be experimental since i havent seen any problem with them) i liked to see for some games that dont have a fixed game state update rate where a lot of reads happen and its VERY important to have a super accurate timer. More info is included in the docs

# Performance
Performance is taken from 150 samples on a script that reads on the same module 10 times. Numbers are in microseconds 

| mapsCacheCycles | Average  | min | max |
| --------|----|--|--|
| 0 (default) |  8555 | 6850 | 15930 | 
| 1 | 1148 | 948 | 3934 |
| 2 | 631 |  122  |  1417  |


### Notes: 
* Because values higher than 1 make some cycles completely cached the results oscillate between completely cached and 1 cache missed like this:
![image](https://github.com/wins1ey/LAST/assets/30161277/829cdd36-fb1f-47c4-9120-ee04cae7d1c7)

* Also i added the documentation for getPID on the documentation
* And an extra check for type string in case the user specifies (or doesnt) an invalid string size